### PR TITLE
Make this tool supports AddmusicK 1.0.9 MMLs

### DIFF
--- a/src/completionItem.ts
+++ b/src/completionItem.ts
@@ -967,6 +967,18 @@ export function subscribeCompletionItem(context: vscode.ExtensionContext): void 
             documentation: new vscode.MarkdownString(hoverMap.hexCommandFA04),
           },
           {
+            label: "$FA $7F (Hot patch preset)",
+            kind: vscode.CompletionItemKind.Method,
+            insertText: new vscode.SnippetString("FA \\$7F $${1:XX}"),
+            documentation: new vscode.MarkdownString(hoverMap.hexCommandFA7F),
+          },
+          {
+            label: "$FA $FE (Hot patch toggle bits)",
+            kind: vscode.CompletionItemKind.Method,
+            insertText: new vscode.SnippetString("FA \\$FE $${1:XX}"),
+            documentation: new vscode.MarkdownString(hoverMap.hexCommandFAFE),
+          },
+          {
             label: "$FB (Arpeggio)",
             kind: vscode.CompletionItemKind.Method,
             insertText: new vscode.SnippetString("FB $${1:XX} $${2:YY} $${3:...}"),

--- a/src/completionItem.ts
+++ b/src/completionItem.ts
@@ -625,6 +625,12 @@ export function subscribeCompletionItem(context: vscode.ExtensionContext): void 
                 documentation: new vscode.MarkdownString(hoverMap.signOption + hoverMap.signOptionNoloop),
               },
               {
+                label: "option amk109hotpatch",
+                kind: vscode.CompletionItemKind.Keyword,
+                insertText: new vscode.SnippetString("option amk109hotpatch"),
+                documentation: new vscode.MarkdownString(hoverMap.signOption + hoverMap.signOptionAmk109hotpatch),
+              },
+              {
                 label: "define",
                 kind: vscode.CompletionItemKind.Keyword,
                 insertText: new vscode.SnippetString("define ${1:variable} ${2:num}"),

--- a/src/completionItem.ts
+++ b/src/completionItem.ts
@@ -1008,6 +1008,18 @@ export function subscribeCompletionItem(context: vscode.ExtensionContext): void 
             insertText: new vscode.SnippetString("FC $${1:WW} $${2:XX} $${3:YY} $${4:ZZ}"),
             documentation: new vscode.MarkdownString(hoverMap.hexCommandFC),
           },
+          {
+            label: "$FD (Tremolo Off)",
+            kind: vscode.CompletionItemKind.Method,
+            insertText: new vscode.SnippetString("FD"),
+            documentation: new vscode.MarkdownString(hoverMap.hexCommandFD),
+          },
+          {
+            label: "$FE (Pitch Envelope Off)",
+            kind: vscode.CompletionItemKind.Method,
+            insertText: new vscode.SnippetString("FE"),
+            documentation: new vscode.MarkdownString(hoverMap.hexCommandFE),
+          },
         ];
         let completionList = new vscode.CompletionList(hexCompletionItems, false);
         return Promise.resolve(completionList);

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1237,7 +1237,7 @@ function refreshDiagnostics(doc: vscode.TextDocument, mmlDiagnostics: vscode.Dia
                   //Empty check
                   if (match.groups.signOptionValue === "" && !inReplacement) {
                     diagnostics.push(createDiagnostic(lineIndex, match, "#option directive missing its first argument.\nValue is empty."));
-                  } else if (!match.groups.signOptionValue.match(/^(?:tempoimmunity|dividetempo|smwvtable|noloop)$/i)) {
+                  } else if (!match.groups.signOptionValue.match(/^(?:tempoimmunity|dividetempo|smwvtable|noloop|amk109hotpatch)$/i)) {
                     diagnostics.push(createDiagnostic(lineIndex, match, "#option directive missing its first argument.\nUnexpected value."));
                   }
                 }

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1691,6 +1691,10 @@ function refreshDiagnostics(doc: vscode.TextDocument, mmlDiagnostics: vscode.Dia
                         case "DF":
                         //Echo off
                         case "F0":
+                        //Tremolo Off
+                        case "FD":
+                        //Pitch Envelope Off
+                        case "FE":
                           hexMatch = undefined;
                           break;
 

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -2369,6 +2369,10 @@ function refreshDiagnostics(doc: vscode.TextDocument, mmlDiagnostics: vscode.Dia
                   }
                 }
 
+                else if (match.groups.pitchSlide !== undefined) {
+                  console.log("found");
+                }
+
                 //else
                 else {
                   if (!inReplacement && unexpectedMatch === undefined) {
@@ -2490,6 +2494,7 @@ function refreshDiagnostics(doc: vscode.TextDocument, mmlDiagnostics: vscode.Dia
                 regexMap.octaveLower,
                 regexMap.octaveRaise,
                 regexMap.loopPoint,
+                regexMap.pitchSlide,
                 regexMap.anything,
               ].join("|"),
               "g"

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1207,7 +1207,7 @@ function refreshDiagnostics(doc: vscode.TextDocument, mmlDiagnostics: vscode.Dia
                   //Version check
                   else if (parseInt(match.groups.signAmkValue) < 2) {
                     diagnostics.push(createDiagnostic(lineIndex, match, "This song was made for a older version of AddmusicK.\nRecommended to set to #amk 2"));
-                  } else if (2 < parseInt(match.groups.signAmkValue)) {
+                  } else if (parseInt(match.groups.signAmkValue) > 4 || parseInt(match.groups.signAmkValue) === 3) {
                     diagnostics.push(createDiagnostic(lineIndex, match, "This song was made for a newer version of AddmusicK. You must update to use this song.\nRecommended to set to #amk 2"));
                   } else {
                     existAmk = true;
@@ -1926,7 +1926,8 @@ function refreshDiagnostics(doc: vscode.TextDocument, mmlDiagnostics: vscode.Dia
                         case "FA":
                           if (hexCount === 1) {
                             //Range check(0-04(4))
-                            if (!(0 <= parseInt("0x" + match.groups.hexCommandValue, 16) && parseInt("0x" + match.groups.hexCommandValue, 16) <= 4) && !inReplacement) {
+                            const matched = parseInt("0x" + match.groups.hexCommandValue, 16);
+                            if (!(0 <= matched && (matched <= 4 || matched === 0x7F || matched === 0xFE)) && !inReplacement) {
                               diagnostics.push(createDiagnostic(lineIndex, match, "Error parsing hex command.\nUndefined command."));
                             }
                           } else if (hexCount >= 2) {

--- a/src/hover.ts
+++ b/src/hover.ts
@@ -1845,6 +1845,25 @@ export class MmlHoverProvider {
                         }
                         hexCount++;
                         break;
+
+                      // Tremolo Off
+                      case "FD":
+                        if ((hover = hoverCheck(lineIndex, match.index, match[0], hoverMap.hexCommandFD)) !== undefined) {
+                          return hover;
+                        }
+
+                        hexMatch = undefined;
+                        break;
+
+                      // Pitch Envelope Off
+                      case "FE":
+                        if ((hover = hoverCheck(lineIndex, match.index, match[0], hoverMap.hexCommandFE)) !== undefined) {
+                          return hover;
+                        }
+
+                        hexMatch = undefined;
+                        break;
+
                     }
                   }
                   isHex = true;

--- a/src/hover.ts
+++ b/src/hover.ts
@@ -923,6 +923,11 @@ export class MmlHoverProvider {
                         return hover;
                       }
                       break;
+                    case "amk109hotpatch":
+                      if ((hover = hoverCheck(lineIndex, match.index, match[0], hoverMap.signOption + hoverMap.signOptionAmk109hotpatch)) !== undefined) {
+                        return hover;
+                      }
+                      break;
                     default:
                       if ((hover = hoverCheck(lineIndex, match.index, match[0], hoverMap.signOption)) !== undefined) {
                         return hover;

--- a/src/hover.ts
+++ b/src/hover.ts
@@ -1757,6 +1757,16 @@ export class MmlHoverProvider {
                                 return hover;
                               }
                               break;
+                            case 0x7F:
+                              if ((hover = hoverCheck(lineIndex, match.index, match[0], hoverMap.hexCommandFA7F)) !== undefined) {
+                                return hover;
+                              }
+                              break;
+                            case 0xFE:
+                              if ((hover = hoverCheck(lineIndex, match.index, match[0], hoverMap.hexCommandFAFE)) !== undefined) {
+                                return hover;
+                              }
+                              break;
                             default:
                               if ((hover = hoverCheck(lineIndex, match.index, match[0], hoverMap.hexCommandFA)) !== undefined) {
                                 return hover;

--- a/src/map.ts
+++ b/src/map.ts
@@ -160,6 +160,43 @@ export const hoverMap = {
   hexCommandFA03: "**Amplify** $FA $03 $XX\n\nMultiplies the volume of the current channel by this value + 1. 0 will not modify the volume, whereas FF will (just shy of) double it.\n\n*$03*\n\n*$XX* : Value to multiply the volume by",
   hexCommandFA04:
     "**Echo buffer reserve** $FA $04 $XX\n\nYou do not need to use this command manually. In fact, you probably shouldn't. This is inserted at the beginning of every song by the program, and doesn't have much use otherwise. Its sole purpose is to reserve an echo buffer large enough for the song's longest echo delay\n\n*$04*\n\n*$XX* : The largest echo buffer you plan to use",
+  hexCommandFA7F: `Applies a preset that replicates the music playback of a different Addmusic. Note that these settings are "global"; i.e. it applies to all channels. Preset IDs are as following (not all of them have been properly implemented yet, and are subject to change as new ones are added on)...
+
+  - $00 - AddmusicK 1.0.8 and earlier (not counting Beta)
+  - $01 - AddmusicK 1.0.9
+  - $02 - AddmusicK Beta
+  - $03 - Romi's Addmusic404
+  - $04 - Addmusic405
+  - $05 - AddmusicM
+  - $06 - carol's MORE.bin
+  - $07 - Vanilla SMW
+  - $08-$7F - Reserved. Do not use.
+  - $80-$FF - User-defined Preset ID. Note that the preceding presets all use a pre-defined set of bits to use: you don't need to follow the same procedure and can do something else instead.
+  `,
+  hexCommandFAFE: `Contains a series of individual patches that can be toggled on and off on a per-bit basis. Note that these settings are "global"; i.e. it applies to all channels. The number of bytes this command takes up is variable: setting the highest bit (%1???????) means you define a second byte that contains an additional seven bits to set on and off (they will otherwise default to off). These bits are pre-defined...  
+  Byte 0: %xyzabcde...  
+  
+  * %x - Define a new byte. Each byte that has this bit set will cause another byte to be defined. By default, all undefined bytes have their bits cleared.
+  * %y - When set, glissando runs for only one note. Otherwise, it runs for two notes.
+  * %z - When set, during buffer initialization done through the $FA $04 command, echo writes are not initially enabled if a zero echo delay is used (the $F1 command will enable them). Otherwise, echo writes are enabled even if a zero echo delay is used: as a side effect, $FF00-$FF03 will be overwritten in ARAM, meaning extremely large songs may lose some data (most likely sample data) when crossing this region. **This must be used at the start of the song on the lowest number channel prior to both any intro markers and notes in order to properly work, otherwise this won't stop $FF00-$FF03 from being overwritten if you are not using echo.**
+  * %a - When set, the $F3 command will zero out the fractional pitch base. Otherwise, this operation is not performed.
+  * %b - When set, $FA $02 (Semitone tune) is not ignored by the $DD command for its target note. Otherwise, $FA $02 (Semitone tune) is ignored by the $DD command's target note.
+  * %c - When set, readahead looks inside loops and superloops. Otherwise, readahead does not look inside loops and superloops.
+  * %d - When set, the GAIN register is written to first, then the ADSR registers when initializing an instrument. Otherwise, the ADSR registers are written to first, then GAIN.
+  * %e - When set, arpeggio notes will not play during rests. Otherwise, they will run normally even if a rest is used.
+  
+  Byte 1: %xyzabcde...  
+  
+  * %x - Define a new byte. Each byte that has this bit set will cause another byte to be defined. By default, all undefined bytes have their bits cleared.
+  * %y - Currently undefined. Please do not set under normal circumstances (unless you're doing your own hot patches: even then, this bit is subject to being used in future Addmusic versions).
+  * %z - Currently undefined. Please do not set under normal circumstances (unless you're doing your own hot patches: even then, this bit is subject to being used in future Addmusic versions).
+  * %a - Currently undefined. Please do not set under normal circumstances (unless you're doing your own hot patches: even then, this bit is subject to being used in future Addmusic versions).
+  * %b - Currently undefined. Please do not set under normal circumstances (unless you're doing your own hot patches: even then, this bit is subject to being used in future Addmusic versions).
+  * %c - Currently undefined. Please do not set under normal circumstances (unless you're doing your own hot patches: even then, this bit is subject to being used in future Addmusic versions).
+  * %d - Currently undefined. Please do not set under normal circumstances (unless you're doing your own hot patches: even then, this bit is subject to being used in future Addmusic versions).
+  * %e - When set, rests are only keyed off if they are detected in readahead. Otherwise, they are keyed off immediately when encountered.
+  
+  All other bytes are currently undefined. They are subject to being used in future Addmusic versions.`,
   hexCommandFB: "**Arpeggio commands** $FB $XX $YY $...\n\n*$XX* : Arpeggio type.\n\n*$YY*\n\n*$...*",
   hexCommandFBXX:
     "**Arpeggio** $FB $XX $YY $...\n\nSpecifies an arpeggio. Each note after this will play with a specified pattern.\n\n*$XX* : Number of notes in the sequence (must be less than $80). If this is 0, then arpeggio is turned off.\n\n*$YY* : The duration of each note\n\n*$...* : The sequence of notes. Each byte is the change in pitch from the currently playing note.",

--- a/src/map.ts
+++ b/src/map.ts
@@ -84,6 +84,17 @@ export const hoverMap = {
   signOptionDividetempo: "\n\n*dividetempo*\n\nSame as #halvetempo, but allows you to specify a value that's not a power of 2.",
   signOptionSmwvtable: "\n\n*smwvtable*\n\nForces the song to use SMW's velocity table instead of the default N-SPC one.",
   signOptionNoloop: "\n\n*noloop*\n\nLets AddmusicK know that this song should only play once and not loop one it is finished.",
+  signOptionAmk109hotpatch: `\n\n*amk109hotpatch*
+
+Activates a series of optional hot patches that were created for AddmusicK 1.0.9 to repair some playback quirks, but were not activated by default to avoid breaking older ports. The complete list of patches applied are as following:
+
+- Glissando only runs for one note instead of two (as it previously mistakenly did).
+- Echo writes are not enabled if the echo delay is set to zero and echo is otherwise not used. For extremely large songs, this prevents $FF00-$FF03 from being overwritten, giving you an extra 256 bytes to work with.
+- $F3 command previously failed to zero out the fractional pitch base due to the code not being added on when ported from AddmusicM (which did not have this kind of feature) to AddmusicK.
+- $FA $02 (Semitone tune) is not ignored by the $DD command for its target note.
+- Readahead looks inside loops and superloops.
+- When setting up an instrument (and for other commands that recycle the instrument setup code via using the updated backup table, such as $FA $01 (GAIN)), GAIN is written to first, then the ADSR voice DSP registers.
+- Arpeggio notes will not play during rests.`,
   signDefine: "**#define**\n\nDefines a constant as existing, and optionally gives it a value.",
   signUndef: "**#undef**\n\nDefines a constant as not existing.",
   signIfdef: "**#ifdef**\n\nAnything from this point to the next #endif will only be compiled if the specified value has been defined by #define.",
@@ -171,8 +182,7 @@ export const hoverMap = {
   - $06 - carol's MORE.bin
   - $07 - Vanilla SMW
   - $08-$7F - Reserved. Do not use.
-  - $80-$FF - User-defined Preset ID. Note that the preceding presets all use a pre-defined set of bits to use: you don't need to follow the same procedure and can do something else instead.
-  `,
+  - $80-$FF - User-defined Preset ID. Note that the preceding presets all use a pre-defined set of bits to use: you don't need to follow the same procedure and can do something else instead.`,
   hexCommandFAFE: `Contains a series of individual patches that can be toggled on and off on a per-bit basis. Note that these settings are "global"; i.e. it applies to all channels. The number of bytes this command takes up is variable: setting the highest bit (%1???????) means you define a second byte that contains an additional seven bits to set on and off (they will otherwise default to off). These bits are pre-defined...  
   Byte 0: %xyzabcde...  
   

--- a/src/map.ts
+++ b/src/map.ts
@@ -171,7 +171,7 @@ Activates a series of optional hot patches that were created for AddmusicK 1.0.9
   hexCommandFA03: "**Amplify** $FA $03 $XX\n\nMultiplies the volume of the current channel by this value + 1. 0 will not modify the volume, whereas FF will (just shy of) double it.\n\n*$03*\n\n*$XX* : Value to multiply the volume by",
   hexCommandFA04:
     "**Echo buffer reserve** $FA $04 $XX\n\nYou do not need to use this command manually. In fact, you probably shouldn't. This is inserted at the beginning of every song by the program, and doesn't have much use otherwise. Its sole purpose is to reserve an echo buffer large enough for the song's longest echo delay\n\n*$04*\n\n*$XX* : The largest echo buffer you plan to use",
-  hexCommandFA7F: `Applies a preset that replicates the music playback of a different Addmusic. Note that these settings are "global"; i.e. it applies to all channels. Preset IDs are as following (not all of them have been properly implemented yet, and are subject to change as new ones are added on)...
+  hexCommandFA7F: `**Hot patch reset** $FA $7F $XX\n\nApplies a preset that replicates the music playback of a different Addmusic. Note that these settings are "global"; i.e. it applies to all channels. Preset IDs are as following (not all of them have been properly implemented yet, and are subject to change as new ones are added on)...
 
   - $00 - AddmusicK 1.0.8 and earlier (not counting Beta)
   - $01 - AddmusicK 1.0.9
@@ -183,7 +183,7 @@ Activates a series of optional hot patches that were created for AddmusicK 1.0.9
   - $07 - Vanilla SMW
   - $08-$7F - Reserved. Do not use.
   - $80-$FF - User-defined Preset ID. Note that the preceding presets all use a pre-defined set of bits to use: you don't need to follow the same procedure and can do something else instead.`,
-  hexCommandFAFE: `Contains a series of individual patches that can be toggled on and off on a per-bit basis. Note that these settings are "global"; i.e. it applies to all channels. The number of bytes this command takes up is variable: setting the highest bit (%1???????) means you define a second byte that contains an additional seven bits to set on and off (they will otherwise default to off). These bits are pre-defined...  
+  hexCommandFAFE: `**Hot patch toggle bits** $FA $FE $XX\n\nContains a series of individual patches that can be toggled on and off on a per-bit basis. Note that these settings are "global"; i.e. it applies to all channels. The number of bytes this command takes up is variable: setting the highest bit (%1???????) means you define a second byte that contains an additional seven bits to set on and off (they will otherwise default to off). These bits are pre-defined...  
   Byte 0: %xyzabcde...  
   
   * %x - Define a new byte. Each byte that has this bit set will cause another byte to be defined. By default, all undefined bytes have their bits cleared.
@@ -214,6 +214,8 @@ Activates a series of optional hot patches that were created for AddmusicK 1.0.9
   hexCommandFB81:
     "**Glissando** $FB $81 $YY $ZZ\n\nIf glissando is turned on, then the current note will be rekeyed at increasingly higher/lower pitches. Analogous to sliding your hand down a keyboard.\n\n*$81*\n\n*$YY* : If glissando is turned on, then the current note will be rekeyed at increasingly higher/lower pitches. Analogous to sliding your hand down a keyboard.\n\n*$ZZ* : The number of semitones to step up or down by for each new note",
   hexCommandFC: "**Remote commands** $FC $WW $XX $YY $ZZ\n\n*$WW* : Address to jump to, low byte (not used for event type 0)\n\n*$XX* : Address to jump to, high byte (not used for event type 0)\n\n*$YY* : The event type\n\n*$ZZ* : How long to wait when using wait types 1 or 2. Note that a value of $00 is treated as $0100",
+  hexCommandFD: "**Tremolo Off** $FD\n\nDisables tremolo for the current channel",
+  hexCommandFE: "**Pitch Envelope Off** $FE\n\nTurns off pitch envelope.",
   quantization: "**Quantization** q\n\nThis command is specified in hex. The first digit specifies how long of a delay there is between each note. Valid values are from 0 to 7, with 7 having the smallest delay. The second digit controls the volume. Valid values are from 0 to F, with F being the loudest.\n\n*Example :*\n```\nq7F q70\n```",
   noise: "**Noise** n\n\nStarts playing noise on the current channel instead of using the current instrument's sample. ADSR and such are preserved, and the effect can be cancelled by using an instrument. The value must be a hex value between 0 and 1F.\n\n*Example :*\n```\nn5 n1F\n```",
   note: "**Note** c,d,e,f,g,a,b\n\nUse + or - after the letter to specify a sharp or flat, respectively. A number should appear after the note; this number should denote the note's duration. 1 is a whole note, 2 is a half note, 4 a quarter note, 8 an eighth note, etc. There are ways to specify notes of other durations; see below.\n\n*Example :*\n```\nc16 g+8 a-1\n```",


### PR DESCRIPTION
According to AddmusicK 1.0.9's readme, I made these changes in this pull request:

- add `#amk 4` support
- add `#option amk109hotpatch` support
- add `$FA $7F $XX` and `$FA $FE $XX` support
- add `$FD` and `$FE` support
- make pitch slide `&` works